### PR TITLE
16 ignore type event and constructor in logic generation

### DIFF
--- a/src/gen.js
+++ b/src/gen.js
@@ -84,17 +84,17 @@ const privateKey = '0x' + process.env.PRIVATE_KEY;
 
     // Iterate over each function
     for (const func of functions) {
-      const { name, inputs, stateMutability } = func;
+      if (func.type === "function")
 
-      if (Array.isArray(inputs) && inputs.length > 0) {
+      if (Array.isArray(func.inputs) && (func.inputs).length > 0) {
         // Generate the function signature
-        const functionSignature = generateFunctionSignature(name, inputs);
+        const functionSignature = generateFunctionSignature(func.name, func.inputs);
 
         // Generate the function definition
         const functionDefinition = generateFunctionDefinition(
           functionSignature,
-          stateMutability,
-          inputs
+          func.stateMutability,
+          func.inputs
         );
 
         // Append the function definition to the JavaScript program
@@ -105,8 +105,8 @@ const privateKey = '0x' + process.env.PRIVATE_KEY;
     // Add the module.exports statement
     jsProgram += "module.exports = {\n";
     for (const func of functions) {
-      const { name } = func;
-      jsProgram += `    ${name},\n`;
+      if (func.type === "function")
+      jsProgram += `    ${func.name},\n`;
     }
     jsProgram += "};";
 

--- a/test/gen.test.js
+++ b/test/gen.test.js
@@ -99,6 +99,88 @@ describe("Generate JS Program", () => {
 
   describe("Generate SDK", () => {
 
+    it("should not generate the function when state type is constructor ", () => {
+
+      const func = [
+        { inputs: [], 
+          stateMutability: 'nonpayable', 
+          type: 'constructor' 
+        },
+        {
+          "inputs": [],
+          "name": "getOwner",
+          "outputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        }
+      ]
+      const name = "owner.json"
+
+      // the stateMutability of the constructor is non-payable
+      // and non-payable has `.send({ from: sender })` in function logic
+
+      // check that `.send({ from: sender })` doesn't exist in the generated program
+      
+
+      const generated = generateJSProgram(func, name)
+
+      assert(!generated.includes(".send({ from: sender })"))
+    });
+
+    it("should not generate the function when state type is event ", () => {
+
+      const func = [
+        {
+          "anonymous": false,
+          "inputs": [
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "oldOwner",
+              "type": "address"
+            },
+            {
+              "indexed": true,
+              "internalType": "address",
+              "name": "newOwner",
+              "type": "address"
+            }
+          ],
+          "name": "OwnerSet",
+          "type": "event"
+        },
+        {
+          "inputs": [],
+          "name": "getOwner",
+          "outputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
+        }
+      ]
+      const name = "owner.json"
+
+      // the name of the event is OwnerSet
+
+      // check that `OwnerSet` doesn't exist in the generated program
+      
+
+      const generated = generateJSProgram(func, name)
+
+      assert(!generated.includes("OwnerSet"))
+    });
+
     it("should succesfully generate a full sdk program", () => {
       const functions = [
         {


### PR DESCRIPTION
This PR adds logic to make the generated sdk program to be of only functions type. Initially, the constructor type and the event type, which are not functions where getting generated. This PR changes that